### PR TITLE
Fixed compat of pkgs in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 FileIO = "1"
-ImageMagick = "≥ 0.7"
-Images = "≥ 0.22"
+ImageMagick = "0.7, 1.0, 1.1"
+Images = "0.18, 0.19, 0.20, 0.21, 0.22"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
To meet guidelines for auto-merging to General registries, compat entries must have upper-bounded versions.