### PR TITLE
Add config vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ julia:
   - 1.2
   - 1.3
   - 1.4
+  - 1.5
 
 env:
   - JULIA_CPU_CORES=2 # travis vm only has 2 cores, but Julia reads the number of hardware cores

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ From the Julia REPL, type `]` to enter the Pkg REPL mode and run:
 pkg> add OCReract
 ```
 
+This is just a wrapper, so it assumes you already have installed [Tesseract](https://tesseract-ocr.github.io/tessdoc/Installation.html).
+
 ## Usage
 
 This is a simple example of usage. For more details check the [Documentation](https://leferrad.github.io/OCReract.jl/dev).

--- a/src/tesseract.jl
+++ b/src/tesseract.jl
@@ -14,9 +14,8 @@ oem_valid_range = 0:4
 function check_tesseract_installed()
     try
         read(`$command --version`, String);
-        @info "Tesseract is properly installed!"
     catch IOError
-        @error "Tesseract is not properly installed!"
+        @error "Tesseract is not properly installed. Command $command not recognized"
     end
 end
 
@@ -65,7 +64,8 @@ Errors / Warnings are reported through `Logging`, so no exceptions are thrown.
     - `oem=1`:   Neural nets LSTM engine only. (Default)
     - `oem=2`:   Legacy + LSTM engines.
     - `oem=3`:   Default, based on what is available.
-- `kwargs`: Other key-value pairs to be sent to Tesseract command as "-c" config variables 
+- `kwargs`: Other key-value pairs to be sent to Tesseract command as "-c" config variables. 
+    You can check the options with `tesseract --print-parameters`.
 
 # Returns
 - `Bool`: indicating whether execution was successful or not
@@ -180,7 +180,8 @@ Errors / Warnings are reported through `Logging`, so no exceptions are thrown.
     - `oem=1`:   Neural nets LSTM engine only. (Default)
     - `oem=2`:   Legacy + LSTM engines.
     - `oem=3`:   Default, based on what is available.
-- `kwargs`: Other key-value pairs to be sent to Tesseract command as "-c" config variables
+- `kwargs`: Other key-value pairs to be sent to Tesseract command as "-c" config variables.
+    You can check the options with `tesseract --print-parameters`.
 
 # Returns
 - `String`: text extracted, or empty string in case an error occurs
@@ -209,7 +210,7 @@ function run_tesseract(
     FileIO.save(input_path, image)
 
     # Run Tesseract!
-    run_tesseract(input_path, output_path, lang=lang, psm=psm, oem=oem, kwargs...)
+    run_tesseract(input_path, output_path, lang=lang, psm=psm, oem=oem; kwargs...)
 
     # Read output into a string
     txt = ""

--- a/test/test_tesseract.jl
+++ b/test/test_tesseract.jl
@@ -46,8 +46,9 @@ function test_run_and_get_output()
 end
 
 function test_run_with_kwargs()
-    result_txt = run_tesseract(Images.load(TEST_ITEMS["noisy"]["path"]), enable_noise_removal=1)
-    @test strip(TEST_ITEMS["noisy"]["text"]) == strip(result_txt)
+    # Set an option that will make OCR bad for this image
+    result_txt = run_tesseract(Images.load(TEST_ITEMS["noisy"]["path"]), tessedit_pageseg_mode=7)
+    @test strip(TEST_ITEMS["noisy"]["text"]) != strip(result_txt)
 end
 
 function test_path_exist()

--- a/test/test_tesseract.jl
+++ b/test/test_tesseract.jl
@@ -45,6 +45,11 @@ function test_run_and_get_output()
     @test strip(TEST_ITEMS["simple"]["text"]) == strip(result_txt)
 end
 
+function test_run_with_kwargs()
+    result_txt = run_tesseract(Images.load(TEST_ITEMS["simple"]["path"]), enable_noise_removal=1)
+    @test strip(TEST_ITEMS["noisy"]["text"]) == strip(result_txt)
+end
+
 function test_path_exist()
     res = run_tesseract("/tmp/not_existing_image.png", "/tmp/res")
     @test res == false

--- a/test/test_tesseract.jl
+++ b/test/test_tesseract.jl
@@ -46,7 +46,7 @@ function test_run_and_get_output()
 end
 
 function test_run_with_kwargs()
-    result_txt = run_tesseract(Images.load(TEST_ITEMS["simple"]["path"]), enable_noise_removal=1)
+    result_txt = run_tesseract(Images.load(TEST_ITEMS["noisy"]["path"]), enable_noise_removal=1)
     @test strip(TEST_ITEMS["noisy"]["text"]) == strip(result_txt)
 end
 
@@ -78,4 +78,6 @@ end
     test_path_exist()
     # Test with bad arguments
     test_bad_arguments()
+    # Test with kwargs
+    test_run_with_kwargs()
 end


### PR DESCRIPTION
This PR is intended to solve #7 by supporting config vars in order to support several options for the execution (as the ones listed in http://www.sk-spell.sk.cx/tesseract-ocr-parameters-in-302-version).

 So as consequence, the user can use the corresponding config var to return confidence levels.