### PR TITLE
Support extra args to tesseract

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,9 @@ Images = "0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 julia = "1"
 
 [extras]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 SimpleMock = "a896ed2c-15a5-4479-b61d-a0e88e2a1d25"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SimpleMock", "Test"]
+test = ["DelimitedFiles", "SimpleMock", "Test"]

--- a/src/tesseract.jl
+++ b/src/tesseract.jl
@@ -138,7 +138,7 @@ function run_tesseract(
         return false
     end
 
-    # NOTE: tesseract ALWAYS add a suffix ".txt" to the result
+    # NOTE: tesseract adds a suffix ".txt" to the result (unless for a TSV result, where the suffix is ".tsv")
     # so, rename the resulting file to call it as the user defined
     output_file = output_path * ("tsv" ∈ extra_args ? ".tsv" : ".txt")
     try

--- a/src/tesseract.jl
+++ b/src/tesseract.jl
@@ -40,7 +40,7 @@ Errors / Warnings are reported through `Logging`, so no exceptions are thrown.
 # Arguments
 - `input_path::String`: Path to the image to be processed
 - `output_path::String`: Path to the text result to be written
-- `extra_args` (`String`s): Optional arguments to change the nature of the output
+- `extra_args::String...`: Optional arguments to change the nature of the output
   (e.g, [`"tsv"`](https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html))
 
 # Keywords
@@ -159,7 +159,7 @@ Errors / Warnings are reported through `Logging`, so no exceptions are thrown.
 
 # Arguments
 - `image`: Image to be processed, in a format compatible with `Images` module.
-- `extra_args` (`String`s): Optional arguments to change the nature of the output
+- `extra_args::String...`: Optional arguments to change the nature of the output
   (e.g, [`"tsv"`](https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html))
 
 # Keywords

--- a/src/tesseract.jl
+++ b/src/tesseract.jl
@@ -140,7 +140,7 @@ function run_tesseract(
 
     # NOTE: tesseract ALWAYS add a suffix ".txt" to the result
     # so, rename the resulting file to call it as the user defined
-    output_file = output_path*".txt"
+    output_file = output_path * ("tsv" ∈ extra_args ? ".tsv" : ".txt")
     try
         mv(output_file, output_path, force=true)
     catch e

--- a/test/test_tesseract.jl
+++ b/test/test_tesseract.jl
@@ -2,6 +2,7 @@ using Images
 using OCReract
 using SimpleMock
 using Test
+using DelimitedFiles
 
 pkg_path = abspath(joinpath(dirname(pathof(OCReract)), ".."))
 
@@ -50,6 +51,26 @@ function test_run_with_kwargs()
     # Set an option that will make OCR bad for this image
     result_txt = run_tesseract(Images.load(TEST_ITEMS["noisy"]["path"]), tessedit_pageseg_mode=7)
     @test strip(TEST_ITEMS["noisy"]["text"]) != strip(result_txt)
+end
+
+function test_tsv()
+    tmp_path = tempname()
+    mkdir(tmp_path)
+    path_to_res = joinpath(tmp_path, "res.tsv")
+    @test run_tesseract(TEST_ITEMS["simple"]["path"], path_to_res, "tsv"; psm=11 #= sparse =#, lang="eng")
+
+    table, header = readdlm(path_to_res, '\t'; header=true, quotes=false)
+    @test header == ["level"  "page_num"  "block_num"  "par_num"  "line_num"  "word_num"  "left"  "top"  "width"  "height"  "conf"  "text"]
+
+    idx = findfirst(==("quick"), table[:,end])
+    @test table[idx, end] == "quick"
+    @test table[idx, #= word_num =# 6] == 2            # the first time "quick" appears, it's the 2nd word on the line
+    @test table[idx, #= top =# 5] == table[idx-1, 5]   # aligned with previous word
+    idx = findnext(==("quick"), table[:,end], idx+1)
+    @test table[idx, #= word_num =# 6] == 4            # the second time "quick" appears, it's the 4th word on the line
+
+    result = run_tesseract(load(TEST_ITEMS["simple"]["path"]), path_to_res, "tsv"; psm=11 #= sparse =#, lang="eng")
+    @test result == read(path_to_res, String)
 end
 
 function test_path_exists()
@@ -102,6 +123,7 @@ end
     test_run_tesseract()
     # Run and get
     test_run_and_get_output()
+    test_tsv()    # with TSV outputs
     # Test with non existent image
     test_path_exists()
     # Test with bad arguments

--- a/test/test_tesseract.jl
+++ b/test/test_tesseract.jl
@@ -60,7 +60,8 @@ function test_tsv()
     @test run_tesseract(TEST_ITEMS["simple"]["path"], path_to_res, "tsv"; psm=11 #= sparse =#, lang="eng")
 
     table, header = readdlm(path_to_res, '\t'; header=true, quotes=false)
-    @test header == ["level"  "page_num"  "block_num"  "par_num"  "line_num"  "word_num"  "left"  "top"  "width"  "height"  "conf"  "text"]
+    @test vec(header) == ["level", "page_num", "block_num", "par_num", "line_num",
+        "word_num", "left", "top", "width", "height", "conf", "text"]
 
     idx = findfirst(==("quick"), table[:,end])
     @test table[idx, end] == "quick"


### PR DESCRIPTION
This allows one to pass additional command-line arguments to tesseract.
This makes it possible to exploit more of its functionality.

For example, in applications where layout is meaningful (e.g., screenshots),
retrieving the full [TSV](https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html) can be very useful.