### PR TITLE
Drop Images in favor of slimmer dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,15 +5,15 @@ version = "1.2.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 FileIO = "1"
-ImageMagick = "0.7, 1.0, 1.1, 1.2"
-Images = "0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
+ImageCore = "0.8, 0.9"
+ImageIO = "0.6"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ This is a simple example of usage. For more details check the [Documentation](ht
 julia> using Images
 julia> using OCReract
 julia> img_path = "/path/to/img.png";
-# In disk
+# With a disk file
 julia> run_tesseract(img_path, "/tmp/res.txt", psm=3, oem=1)
-# In memory
-julia> img = Images.load(img_path);
+# Image in memory
+julia> img = load(img_path);
 julia> res_text = run_tesseract(img, psm=3, oem=1);
 julia> println(strip(res_text));
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,13 +33,13 @@ julia> read(`cat $res_path`, String)
 
 #### In memory
 
-`OCReract` uses [JuliaImages](https://juliaimages.org/latest/) module to process images in memory. So, the image should be loaded with `Images` module to then execute `run_tesseract` to retrieve the result as a `String`.
+`OCReract` uses [JuliaImages](https://juliaimages.org/latest/) module to process images in memory. So, the image should be loaded with `Images` module (or the lighter-weight combination `using ImageCore, FileIO`) to then execute `run_tesseract` to retrieve the result as a `String`.
 
 ```julia-repl
 julia> using Images
 julia> using OCReract
 julia> img_path = "https://raw.githubusercontent.com/leferrad/OCReract.jl/master/test/files/noisy.png";
-julia> img = Images.load(img_path);
+julia> img = load(img_path);
 julia> res_text = run_tesseract(img);
 julia> println(strip(res_text))
 Noisy image

--- a/src/OCReract.jl
+++ b/src/OCReract.jl
@@ -18,7 +18,7 @@ julia> img_path = "/path/to/img.png";
 # In disk
 julia> run_tesseract(img_path, "/tmp/res.txt", psm=3, oem=1)
 # In memory
-julia> img = Images.load(img_path);
+julia> img = load(img_path);
 julia> res_text = run_tesseract(img, psm=3, oem=1);
 julia> println(strip(res_text));
 ```

--- a/src/tesseract.jl
+++ b/src/tesseract.jl
@@ -1,5 +1,5 @@
 using FileIO
-using Images
+using ImageCore
 using Logging
 
 export
@@ -197,7 +197,7 @@ Errors / Warnings are reported through `Logging`, so no exceptions are thrown.
 julia> using Images;
 julia> using OCReract;
 julia> img_path = "/path/to/img.png";
-julia> img = Images.load(img_path);
+julia> img = load(img_path);
 julia> res_text = run_tesseract(img, psm=3, oem=1);
 julia> println(strip(res_text));
 ```

--- a/test/test_tesseract.jl
+++ b/test/test_tesseract.jl
@@ -1,4 +1,5 @@
-using Images
+using ImageCore
+using FileIO
 using OCReract
 using SimpleMock
 using Test
@@ -43,13 +44,13 @@ function test_run_tesseract()
 end
 
 function test_run_and_get_output()
-    result_txt = run_tesseract(Images.load(TEST_ITEMS["simple"]["path"]))
+    result_txt = run_tesseract(load(TEST_ITEMS["simple"]["path"]))
     @test strip(TEST_ITEMS["simple"]["text"]) == strip(result_txt)
 end
 
 function test_run_with_kwargs()
     # Set an option that will make OCR bad for this image
-    result_txt = run_tesseract(Images.load(TEST_ITEMS["noisy"]["path"]), tessedit_pageseg_mode=7)
+    result_txt = run_tesseract(load(TEST_ITEMS["noisy"]["path"]), tessedit_pageseg_mode=7)
     @test strip(TEST_ITEMS["noisy"]["text"]) != strip(result_txt)
 end
 


### PR DESCRIPTION
On my machine, this reduces the time for `using OCReract` from
3.6s to 1.1s.

Also, at this point ImageIO is considerably better at PNG IO than ImageMagick,
so I took the opportunity to update that dependency as well.